### PR TITLE
40 configure contact us page to enable users to send messages to a business email address

### DIFF
--- a/app/backend/index.js
+++ b/app/backend/index.js
@@ -1,3 +1,4 @@
+// backend/index.js
 import { prompt } from "./prompts.mjs";
 import cors from "cors";
 import express from "express";
@@ -5,73 +6,68 @@ import express from "express";
 // email support
 import nodemailer from "nodemailer";
 
+// rate limiting
+import { rateLimit } from "express-rate-limit";
+
 const app = express();
 const PORT = 5000;
 
 app.use(cors());
 app.use(express.json());
 
-/*
-  ---------- MAIL TRANSPORT (Ethereal for development) ----------
-  I ended up having to revert from the Gmail/SMTP env-based transport to an
-  Ethereal test account which gets created at server startup.
+// Rate limiting tuning
+// tune these via env:
+//   RATE_LIMIT_WINDOW_MS (default 15 min)
+//   RATE_LIMIT_MAX        (default 100 req/window)
+//   CONTACT_LIMIT_WINDOW_MS (default 10 min)
+//   CONTACT_LIMIT_MAX       (default 10 req/window)
+const apiLimiter = rateLimit({
+  windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS ?? 15 * 60 * 1000),
+  max: Number(process.env.RATE_LIMIT_MAX ?? 100),
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
-  Ethereal advantages:
-    - No real email is sent
-    - we will get a preview URL to view the email in a browser
-    - No app passwords or 2 step authenication needed
+// Stricter limiter for contact (email-sending) endpoints
+const contactLimiter = rateLimit({
+  windowMs: Number(process.env.CONTACT_LIMIT_WINDOW_MS ?? 10 * 60 * 1000),
+  max: Number(process.env.CONTACT_LIMIT_MAX ?? 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
-  To test this functionality with docker:
-  enter the following into the Git Bash terminal:
-  
-  docker compose up -d
+// Apply general limiter to all API routes
+app.use("/api", apiLimiter);
 
-  you'll see a message like this:
-  "Ethereal SMTP ready"
-  "Login: bswyuptjdpma3gol@ethereal.email"
-  "Pass:  2RJvrHgeSftYNNMsZ8"
+// ---------- Nodemailer transport ----------
+// Set these in backend/.env (examples):
+//   SMTP_HOST=smtp.gmail.com
+//   SMTP_PORT=465
+//   SMTP_USER=your.email@yourdomain.com
+//   SMTP_PASS=your_app_password_or_smtp_password
+//   CONTACT_TO=owner@yourdomain.com
+//   CONTACT_FROM=no-reply@yourdomain.com   (optional; defaults to SMTP_USER)
+const {
+  SMTP_HOST,
+  SMTP_PORT,
+  SMTP_USER,
+  SMTP_PASS,
+  CONTACT_TO,
+  CONTACT_FROM,
+} = process.env;
 
-  then on a separate Git bash terminal, enter:
-  
-  docker compose logs -f backend
-  Then go back to the the PromptMailAI Contact Us Page from the UI, type in a name, an email, a message and press enter...check back with the terminal
+// defaults for Gmail
+const transport = nodemailer.createTransport({
+  host: SMTP_HOST || "smtp.gmail.com",
+  port: Number(SMTP_PORT) || 465,
+  secure: (SMTP_PORT ? Number(SMTP_PORT) === 465 : true), // true for 465, false for 587
+  auth: {
+    user: SMTP_USER,
+    pass: SMTP_PASS,
+  },
+});
 
-  The terminal will show something like this.. click it and you'll see the message from the UI:
-  Ethereal Preview URL: https://ethereal.email/message/aJbOvEtUvPQALbk8aJbRO2XUKwn.zTRMAAAAAdX1tUsUmJCk9DDRGnYHJpo
-
-
-
-
-
-*/
-let transport = null;
-let etherealAccount = null;
-
-(async () => {
-  try {
-    etherealAccount = await nodemailer.createTestAccount();
-
-    transport = nodemailer.createTransport({
-      host: etherealAccount.smtp.host,
-      port: etherealAccount.smtp.port,
-      secure: etherealAccount.smtp.secure, // true for 465, false otherwise
-      auth: {
-        user: etherealAccount.user,
-        pass: etherealAccount.pass,
-      },
-    });
-
-    console.log("Ethereal SMTP ready ✅");
-    console.log("Login:", etherealAccount.user);
-    console.log("Pass: ", etherealAccount.pass);
-  } catch (err) {
-    console.error("Failed to initialize Ethereal transport:", err);
-  }
-})();
-
-
-//Health-check for mailer
-
+//  Health-check for mailer covered by /api limiter 
 app.get("/api/contact/health", async (_req, res) => {
   if (!transport) {
     return res.json({ ok: false, error: "Mail transport not initialized yet." });
@@ -86,7 +82,7 @@ app.get("/api/contact/health", async (_req, res) => {
   }
 });
 
-// API route
+//  API Prompt 
 app.post("/api/prompt", async (req, res) => {
   const { text, tone } = req.body;
   try {
@@ -97,12 +93,12 @@ app.post("/api/prompt", async (req, res) => {
   }
 });
 
-// Contact Us Route using the ethereal transport
-app.post("/api/contact", async (req, res) => {
+// Contact Us Route
+app.post("/api/contact", contactLimiter, async (req, res) => {
   try {
     const { name, email, message } = req.body || {};
 
-    // validation 
+    // validation
     if (!name || typeof name !== "string") {
       return res.status(400).json({ error: "Name is required." });
     }
@@ -114,10 +110,12 @@ app.post("/api/contact", async (req, res) => {
       return res.status(400).json({ error: "Message is required." });
     }
 
-    if (!transport) {
+    const to = CONTACT_TO || SMTP_USER;
+    const from = CONTACT_FROM || SMTP_USER;
+    if (!SMTP_USER || !SMTP_PASS) {
       return res
         .status(500)
-        .json({ error: "Email transport is not initialized on the server." });
+        .json({ error: "Email transport is not configured on the server." });
     }
 
     const subject = `PromptMail Contact: ${name} <${email}>`;
@@ -137,30 +135,24 @@ ${message}
       </div>
     `;
 
-    
-    const info = await transport.sendMail({
-      to: "contact@promptmail.ethereal",           
-      from: `"PromptMail Contact" <no-reply@promptmail.dev>`,
-      replyTo: `${name} <${email}>`,               // replies go back to the user
+    await transport.sendMail({
+      to,
+      from,
+      replyTo: `${name} <${email}>`, // enables replies to go back to the user
       subject,
       text: textBody,
       html: htmlBody,
     });
 
-    const previewUrl = nodemailer.getTestMessageUrl(info);
-    if (previewUrl) {
-      console.log("Ethereal Preview URL:", previewUrl);
-    }
-
-    // Keep response shape compatible (ok: true). Extra preview field is additive/non-breaking.
-    res.json({ ok: true, preview: previewUrl || null });
+    res.json({ ok: true });
   } catch (err) {
     console.error("Contact form send failed:", err);
-    res.status(500).json({ error: "Failed to send your message. Please try again later." });
+    res
+      .status(500)
+      .json({ error: "Failed to send your message. Please try again later." });
   }
 });
 
-// ------------------------------------------------------------------------
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
 });

--- a/app/backend/index.js
+++ b/app/backend/index.js
@@ -21,7 +21,26 @@ app.use(express.json());
     - we will get a preview URL to view the email in a browser
     - No app passwords or 2 step authenication needed
 
-  To test this functionality 
+  To test this functionality with docker:
+  enter the following into the Git Bash terminal:
+  
+  docker compose up -d
+
+  you'll see a message like this:
+  "Ethereal SMTP ready"
+  "Login: bswyuptjdpma3gol@ethereal.email"
+  "Pass:  2RJvrHgeSftYNNMsZ8"
+
+  then on a separate Git bash terminal, enter:
+  
+  docker compose logs -f backend
+  Then go back to the the PromptMailAI Contact Us Page from the UI, type in a name, an email, a message and press enter...check back with the terminal
+
+  The terminal will show something like this.. click it and you'll see the message from the UI:
+  Ethereal Preview URL: https://ethereal.email/message/aJbOvEtUvPQALbk8aJbRO2XUKwn.zTRMAAAAAdX1tUsUmJCk9DDRGnYHJpo
+
+
+
 
 
 */

--- a/app/backend/index.js
+++ b/app/backend/index.js
@@ -21,6 +21,8 @@ app.use(express.json());
     - we will get a preview URL to view the email in a browser
     - No app passwords or 2 step authenication needed
 
+  To test this functionality 
+
 
 */
 let transport = null;

--- a/app/backend/index.js
+++ b/app/backend/index.js
@@ -1,7 +1,9 @@
-// backend/index.js
 import { prompt } from "./prompts.mjs";
 import cors from "cors";
 import express from "express";
+
+// email support
+import nodemailer from "nodemailer";
 
 const app = express();
 const PORT = 5000;
@@ -9,6 +11,61 @@ const PORT = 5000;
 app.use(cors());
 app.use(express.json());
 
+/*
+  ---------- MAIL TRANSPORT (Ethereal for development) ----------
+  I ended up having to revert from the Gmail/SMTP env-based transport to an
+  Ethereal test account which gets created at server startup.
+
+  Ethereal advantages:
+    - No real email is sent
+    - we will get a preview URL to view the email in a browser
+    - No app passwords or 2 step authenication needed
+
+
+*/
+let transport = null;
+let etherealAccount = null;
+
+(async () => {
+  try {
+    etherealAccount = await nodemailer.createTestAccount();
+
+    transport = nodemailer.createTransport({
+      host: etherealAccount.smtp.host,
+      port: etherealAccount.smtp.port,
+      secure: etherealAccount.smtp.secure, // true for 465, false otherwise
+      auth: {
+        user: etherealAccount.user,
+        pass: etherealAccount.pass,
+      },
+    });
+
+    console.log("Ethereal SMTP ready ✅");
+    console.log("Login:", etherealAccount.user);
+    console.log("Pass: ", etherealAccount.pass);
+  } catch (err) {
+    console.error("Failed to initialize Ethereal transport:", err);
+  }
+})();
+
+
+//Health-check for mailer
+
+app.get("/api/contact/health", async (_req, res) => {
+  if (!transport) {
+    return res.json({ ok: false, error: "Mail transport not initialized yet." });
+  }
+  try {
+    await transport.verify();
+    return res.json({ ok: true });
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ ok: false, error: err?.message || "Mail transport not ready" });
+  }
+});
+
+// API route
 app.post("/api/prompt", async (req, res) => {
   const { text, tone } = req.body;
   try {
@@ -19,6 +76,70 @@ app.post("/api/prompt", async (req, res) => {
   }
 });
 
+// Contact Us Route using the ethereal transport
+app.post("/api/contact", async (req, res) => {
+  try {
+    const { name, email, message } = req.body || {};
+
+    // validation 
+    if (!name || typeof name !== "string") {
+      return res.status(400).json({ error: "Name is required." });
+    }
+    const emailOk = typeof email === "string" && /^\S+@\S+\.\S+$/.test(email);
+    if (!emailOk) {
+      return res.status(400).json({ error: "A valid email is required." });
+    }
+    if (!message || typeof message !== "string") {
+      return res.status(400).json({ error: "Message is required." });
+    }
+
+    if (!transport) {
+      return res
+        .status(500)
+        .json({ error: "Email transport is not initialized on the server." });
+    }
+
+    const subject = `PromptMail Contact: ${name} <${email}>`;
+    const textBody = `New Contact Message
+
+From: ${name} <${email}>
+
+Message:
+${message}
+`;
+    const htmlBody = `
+      <div style="font-family:system-ui,Arial,sans-serif;line-height:1.4">
+        <h2>New Contact Message</h2>
+        <p><strong>From:</strong> ${name} &lt;${email}&gt;</p>
+        <p><strong>Message:</strong></p>
+        <pre style="white-space:pre-wrap">${message}</pre>
+      </div>
+    `;
+
+    
+    const info = await transport.sendMail({
+      to: "contact@promptmail.ethereal",           
+      from: `"PromptMail Contact" <no-reply@promptmail.dev>`,
+      replyTo: `${name} <${email}>`,               // replies go back to the user
+      subject,
+      text: textBody,
+      html: htmlBody,
+    });
+
+    const previewUrl = nodemailer.getTestMessageUrl(info);
+    if (previewUrl) {
+      console.log("Ethereal Preview URL:", previewUrl);
+    }
+
+    // Keep response shape compatible (ok: true). Extra preview field is additive/non-breaking.
+    res.json({ ok: true, preview: previewUrl || null });
+  } catch (err) {
+    console.error("Contact form send failed:", err);
+    res.status(500).json({ error: "Failed to send your message. Please try again later." });
+  }
+});
+
+// ------------------------------------------------------------------------
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
 });

--- a/app/backend/package-lock.json
+++ b/app/backend/package-lock.json
@@ -9,14 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.7",
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "nodemailer": "^6.9.13",
         "openai": "^5.10.2"
       },
       "devDependencies": {
         "chai": "^5.2.1",
         "mocha": "^11.7.1",
+        "nodemon": "^3.1.10",
         "supertest": "^7.1.3"
       }
     },
@@ -114,6 +117,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -142,8 +159,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -151,6 +178,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -180,6 +220,19 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browser-stdout": {
@@ -415,7 +468,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -433,6 +485,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -552,7 +611,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -677,7 +735,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -776,6 +833,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -820,6 +890,26 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -838,10 +928,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -858,7 +947,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -868,7 +956,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -911,6 +998,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -990,6 +1092,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1028,7 +1143,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -1099,6 +1213,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1114,6 +1235,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1122,6 +1266,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -1387,6 +1554,139 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nodemon/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1561,6 +1861,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1573,6 +1886,19 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -1688,6 +2014,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -1848,6 +2187,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/statuses": {
@@ -2027,6 +2379,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2034,6 +2399,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/type-is": {
@@ -2049,6 +2424,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -14,13 +14,16 @@
   "type": "module",
   "dependencies": {
     "cors": "^2.8.5",
+    "axios": "^1.7.7",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
-    "openai": "^5.10.2"
+    "openai": "^5.10.2",
+    "nodemailer": "^6.9.13"
   },
   "devDependencies": {
     "chai": "^5.2.1",
     "mocha": "^11.7.1",
-    "supertest": "^7.1.3"
+    "supertest": "^7.1.3",
+    "nodemon": "^3.1.10"
   }
 }

--- a/app/backend/prompts.mjs
+++ b/app/backend/prompts.mjs
@@ -1,11 +1,17 @@
+// backend/prompts.mjs
 import OpenAI from "openai";
 import dotenv from "dotenv";
 
 dotenv.config();
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+// Lazy init: backend wont crash if no key is present. it will only throw when used. I need this to test the contact us page messaging functionality
+let openai = null;
+if (process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim()) {
+  openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY.trim(),
+  });
+}
+
 const PROMPT_TONES = {
   summary: {
     id: "pmpt_6871a11f16d08194b371b0ea9cfe79140092b39df4f550c3",
@@ -38,12 +44,18 @@ const PROMPT_TONES = {
 };
 
 export const prompt = async (text, tone) => {
+  if (!openai) {
+    // Don’t crash the server at startup; return a clear error only when route is used
+    throw new Error("OPENAI_API_KEY is not set on the server.");
+  }
+
+  const meta = PROMPT_TONES[tone];
+  if (!meta) {
+    throw new Error(`Unknown tone '${tone}'.`);
+  }
 
   const response = await openai.responses.create({
-    prompt: {
-      id: PROMPT_TONES[tone].id,
-      version: PROMPT_TONES[tone].version,
-    },
+    prompt: { id: meta.id, version: meta.version },
     input: [{ role: "user", content: text }],
     max_output_tokens: 2048,
   });

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.11.0",
         "bootstrap": "^5.3.7",
         "react": "^19.1.0",
         "react-bootstrap": "^2.10.10",
@@ -2609,6 +2610,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -2755,6 +2772,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2958,6 +2988,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -3103,6 +3145,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3139,6 +3190,20 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3169,6 +3234,51 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -3498,6 +3608,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3513,6 +3643,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-readdir-recursive": {
@@ -3548,7 +3694,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3570,6 +3715,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -3641,6 +3823,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -3649,11 +3843,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4169,6 +4389,36 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4701,6 +4951,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "node run-tests.cjs"
   },
   "dependencies": {
+    "axios": "^1.11.0",
     "bootstrap": "^5.3.7",
     "react": "^19.1.0",
     "react-bootstrap": "^2.10.10",
@@ -21,9 +22,9 @@
   "devDependencies": {
     "@babel/cli": "^7.28.0",
     "@babel/core": "^7.24.0",
-    "@babel/register": "^7.24.0",
     "@babel/preset-env": "^7.24.7",
     "@babel/preset-react": "^7.23.3",
+    "@babel/register": "^7.24.0",
     "@eslint/js": "^9.30.1",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",

--- a/app/frontend/src/pages/Citations.jsx
+++ b/app/frontend/src/pages/Citations.jsx
@@ -50,6 +50,29 @@ function Citations() {
               https://getbootstrap.com
             </a>
           </li>
+          <li className="list-group-item">
+            <strong>Ethereal Email</strong><br />
+            Ethereal Email is a fake SMTP service for testing email sending without delivering to real recipients. 
+            It allows developers to preview messages in a web interface.<br />
+            <a href="https://ethereal.email" target="_blank" rel="noopener noreferrer">
+              https://ethereal.email
+            </a>
+          </li>
+          <li className="list-group-item">
+            <strong>Axios</strong><br />
+            Axios is used to handle HTTP requests between the frontend and backend APIs, supporting features like 
+            promises and request/response interceptors.<br />
+            <a href="https://axios-http.com" target="_blank" rel="noopener noreferrer">
+              https://axios-http.com
+            </a>
+          </li>
+          <li className="list-group-item">
+            <strong>Mocha</strong><br />
+            Mocha is a JavaScript testing framework used to run and organize backend unit and integration tests.<br />
+            <a href="https://mochajs.org" target="_blank" rel="noopener noreferrer">
+              https://mochajs.org
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/app/frontend/src/pages/ContactUs.jsx
+++ b/app/frontend/src/pages/ContactUs.jsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
+import axios from 'axios';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import './ContactUs.css';
+
+const API_BASE =
+  import.meta.env?.VITE_API_BASE?.trim() || 'http://localhost:5000';
 
 function ContactUs() {
   const [formData, setFormData] = useState({
@@ -9,6 +13,9 @@ function ContactUs() {
     message: ''
   });
   const [emailError, setEmailError] = useState('');
+  const [sending, setSending] = useState(false);
+  const [serverError, setServerError] = useState('');
+  const [sentOk, setSentOk] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -17,25 +24,47 @@ function ContactUs() {
       [name]: value
     }));
     if (name === 'email') {
-      // clear error as user types
       setEmailError('');
     }
+    setServerError('');
+    setSentOk(false);
   };
 
   const validateEmail = (email) => {
-    // simple regex: at least one character before @, domain, and TLD
     const re = /^\S+@\S+\.\S+$/;
     return re.test(email);
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!validateEmail(formData.email)) {
       setEmailError('Please enter a valid email address.');
       return;
     }
-    alert('Your message has been submitted!');
-    // TODO: Connect to backend API if needed
+
+    try {
+      setSending(true);
+      setServerError('');
+      setSentOk(false);
+
+      await axios.post(`${API_BASE}/api/contact`, {
+        name: formData.name,
+        email: formData.email,
+        message: formData.message
+      });
+
+      setSentOk(true);
+      // clear the form
+      setFormData({ name: '', email: '', message: '' });
+    } catch (err) {
+      const msg =
+        err?.response?.data?.error ||
+        err?.message ||
+        'Failed to send. Please try again.';
+      setServerError(msg);
+    } finally {
+      setSending(false);
+    }
   };
 
   return (
@@ -50,6 +79,18 @@ function ContactUs() {
 
       {/* Contact Form Section */}
       <div className="contact-section">
+        {/* Status messages */}
+        {sentOk && (
+          <div className="alert alert-success" role="alert">
+            ✅ Your message has been sent. We’ll be in touch!
+          </div>
+        )}
+        {serverError && (
+          <div className="alert alert-danger" role="alert">
+            ❌ {serverError}
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} noValidate>
           <div className="form-group mb-3">
             <label htmlFor="name" className="form-label">Your Name</label>
@@ -62,6 +103,7 @@ function ContactUs() {
               onChange={handleChange}
               placeholder="Enter your name"
               required
+              disabled={sending}
             />
           </div>
 
@@ -76,6 +118,7 @@ function ContactUs() {
               onChange={handleChange}
               placeholder="Enter your email"
               required
+              disabled={sending}
             />
             {emailError && (
               <div className="invalid-feedback">
@@ -95,13 +138,18 @@ function ContactUs() {
               onChange={handleChange}
               placeholder="Type your message here..."
               required
+              disabled={sending}
             ></textarea>
           </div>
 
-          {/* Enhanced Send Message Button */}
+          {/* Send Message Button */}
           <OverlayTrigger placement="bottom" overlay={<Tooltip>Send your message</Tooltip>}>
-            <button type="submit" className="btn btn-primary w-100 highlight-hover">
-              Send Message
+            <button
+              type="submit"
+              className="btn btn-primary w-100 highlight-hover"
+              disabled={sending}
+            >
+              {sending ? 'Sending…' : 'Send Message'}
             </button>
           </OverlayTrigger>
         </form>

--- a/app/frontend/src/pages/ContactUs.jsx
+++ b/app/frontend/src/pages/ContactUs.jsx
@@ -82,12 +82,12 @@ function ContactUs() {
         {/* Status messages */}
         {sentOk && (
           <div className="alert alert-success" role="alert">
-            ✅ Your message has been sent. We’ll be in touch!
+             Your message has been sent. We’ll be in touch!
           </div>
         )}
         {serverError && (
           <div className="alert alert-danger" role="alert">
-            ❌ {serverError}
+             {serverError}
           </div>
         )}
 


### PR DESCRIPTION
-updated citations page to show mocha for backend testing, axios for handling http requests between the front end and backend APIs
-updated the backend to allow functionality of the contact us page messaging button
     - started with GMAIL/SMTP env based transport and shifted to ethereal email to avoid 2 step authentication.
               - added hook and error handling in the contacts.jsx page
               - updated the index.js to use the ethereal mail transport via nodemailer
               - added testing commentary on lines 15 thru 39 for how to demonstrate functionality from docker.
               - added dependencies to package.json
               - added lazy init to enable testing of backend for messaging capability in docker in the prompts.mjs file.